### PR TITLE
Rocket_35_01 - Fix part description

### DIFF
--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
@@ -34,7 +34,7 @@ category = Propulsion
 subcategory = 0
 title = SRM-S Sounding Rocket Motor
 manufacturer = Umbra Space Industries
-description = A cardboard tube, stuffed with explosives.  What could possibly go wrong?  This tiny motor is ideal for the second stage of a sounding rocket, with better ISP at the espese of thrust. 
+description = A cardboard tube, stuffed with explosives.  What could possibly go wrong?  This tiny motor is ideal for the second stage of a sounding rocket, with better ISP at the expense of thrust. 
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0


### PR DESCRIPTION
Fixes a typo in the description of the SRM-S rocket motor.  Thought I'd save you the effort. Thanks for a great mod.