### PR TITLE
Balancing with stock

### DIFF
--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
@@ -59,7 +59,7 @@ MODULE
 	exhaustDamage = True
 	ignitionThreshold = 0.1
 	minThrust = 0
-	maxThrust = 7.85
+	maxThrust = 9
 	heatProduction = 100
 	fxOffset = 0, 0, 0
 	PROPELLANT

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
@@ -31,7 +31,7 @@ sound_vent_soft = disengage
 // --- editor parameters ---
 TechRequired = fuelSystems
 entryCost = 0
-cost = 30
+cost = 45
 category = Propulsion
 subcategory = 0
 title = Mini Aerospike Engine
@@ -48,7 +48,7 @@ maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 5
-maxTemp = 3400 
+maxTemp = 2000
 
 stagingIcon = LIQUID_ENGINE
 
@@ -59,8 +59,8 @@ MODULE
 	exhaustDamage = True
 	ignitionThreshold = 0.1
 	minThrust = 0
-	maxThrust = 8.5
-	heatProduction = 550
+	maxThrust = 7.85
+	heatProduction = 100
 	fxOffset = 0, 0, 0
 	PROPELLANT
 	{
@@ -75,8 +75,9 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 380
-  	 key = 1 378
+   	 key = 0 325
+  	 key = 1 300
+  	 key = 20 0.001
  	}
 }
 


### PR DESCRIPTION
ISP lowered to match stock aerospike and extra key added. Price increased so cost/KN thrust matches stock (cheapest/KN engine). maxThrust is now atmospheric thrust so lowered it so vac thrust stays the same like they did for stock. Max temp and heat production lowered like stock. Don't think bulkheadProfiles is needed.