### PR TITLE
Quick fixes - 0.625m chute title and SRM power curve

### DIFF
--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_625.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_625.cfg
@@ -30,7 +30,7 @@ entryCost = 0
 cost = 250
 category = Utility
 subcategory = 0
-title = Nosecone Parachute (0.35m)
+title = Nosecone Parachute (0.625m)
 manufacturer = Umbra Space Industries
 description = A cardboard cone stuffed with a spare parachute.  A handy, aerodynamic topper for your sounding rocket. 
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
@@ -70,8 +70,8 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 220
-  	 key = 1 235
+  	 key = 0 235
+   	 key = 1 220
  	}
 	
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_02.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_02.cfg
@@ -70,8 +70,8 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 220
-  	 key = 1 235
+  	 key = 0 235
+   	 key = 1 220
  	}
 	
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_625_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_625_01.cfg
@@ -70,8 +70,8 @@ MODULE
 	}
 	atmosphereCurve
  	{
-   	 key = 0 220
-  	 key = 1 235
+  	 key = 0 235
+   	 key = 1 220
  	}
 	
 }


### PR DESCRIPTION
I changed the title of the 0.625m chute nose cone to be different from that of the 0.35m part.

I also flipped the Isp curve on the solids to have the higher Isp at the vacuum end. Thought that might have been what you were going for.