### PR TITLE
Move size00 out to patch

### DIFF
--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Adapter.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Adapter.cfg
@@ -38,7 +38,7 @@ minimum_drag = 0.1
 angularDrag = .25
 crashTolerance = 8
 maxTemp = 3400
-bulkheadProfiles = size0, size00
+bulkheadProfiles = size0
  
 
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Adapter.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Adapter.cfg
@@ -38,7 +38,7 @@ minimum_drag = 0.1
 angularDrag = .25
 crashTolerance = 8
 maxTemp = 3400
-
+bulkheadProfiles = size0, size00
  
 
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
@@ -49,7 +49,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-bulkheadProfiles = size00
+bulkheadProfiles = size0
 
 stagingIcon = LIQUID_ENGINE
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Aerospike.cfg
@@ -49,6 +49,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
+bulkheadProfiles = size00
 
 stagingIcon = LIQUID_ENGINE
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Battery.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Battery.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3400 
+bulkheadProfiles = srf
 
 RESOURCE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Decoupler.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Decoupler.cfg
@@ -45,6 +45,7 @@ crashTolerance = 8
 maxTemp = 3400
 explosionPotential = 0.1
 fuelCrossFeed = False
+bulkheadProfiles = size00
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Decoupler.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Decoupler.cfg
@@ -45,7 +45,7 @@ crashTolerance = 8
 maxTemp = 3400
 explosionPotential = 0.1
 fuelCrossFeed = False
-bulkheadProfiles = size00
+bulkheadProfiles = size0
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Gyro.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Gyro.cfg
@@ -38,7 +38,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3100 
-
+bulkheadProfiles = size00,srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Gyro.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Gyro.cfg
@@ -38,7 +38,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3100 
-bulkheadProfiles = size00,srf
+bulkheadProfiles = size0,srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_LaunchStick.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_LaunchStick.cfg
@@ -42,6 +42,7 @@ angularDrag = 1
 crashTolerance = 3
 maxTemp = 3400
 explosionPotential = 0.1
+bulkheadProfiles = size00,srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_LaunchStick.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_LaunchStick.cfg
@@ -42,7 +42,7 @@ angularDrag = 1
 crashTolerance = 3
 maxTemp = 3400
 explosionPotential = 0.1
-bulkheadProfiles = size00,srf
+bulkheadProfiles = size0,srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_35.cfg
@@ -48,12 +48,11 @@ mass = 0.05
 	breakingTorque = 50
 	bodyLiftMultiplier = 0
 	stageOffset = -1
-	bulkheadProfiles = size1, srf
 
 
 crashTolerance = 8
 maxTemp = 3100 
-bulkheadProfiles = size00
+bulkheadProfiles = size0
 
 stageOffset = -1
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_35.cfg
@@ -53,6 +53,7 @@ mass = 0.05
 
 crashTolerance = 8
 maxTemp = 3100 
+bulkheadProfiles = size00
 
 stageOffset = -1
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_625.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_625.cfg
@@ -45,6 +45,7 @@ minimum_drag = 0.1
 angularDrag = 0.25
 crashTolerance = 8
 maxTemp = 3100 
+bulkheadProfiles = size0
 
 stageOffset = -1
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PackChute_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PackChute_35.cfg
@@ -42,7 +42,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3100 
-
+bulkheadProfiles = srf
 
 stageOffset = -1
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload01.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 3
 maxTemp = 3400 
+bulkheadProfiles = srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload02.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload02.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 3
 maxTemp = 3400 
+bulkheadProfiles = srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload03.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload03.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3400 
+bulkheadProfiles = srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload04.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Payload04.cfg
@@ -37,7 +37,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3400 
-
+bulkheadProfiles = srf
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadFairing_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadFairing_35.cfg
@@ -42,6 +42,7 @@ minimum_drag = 0.1
 angularDrag = .25
 crashTolerance = 8
 maxTemp = 3400
+bulkheadProfiles = size00
 explosionPotential = 0.1
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadFairing_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadFairing_35.cfg
@@ -42,7 +42,7 @@ minimum_drag = 0.1
 angularDrag = .25
 crashTolerance = 8
 maxTemp = 3400
-bulkheadProfiles = size00
+bulkheadProfiles = size0
 explosionPotential = 0.1
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadFairing_625.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadFairing_625.cfg
@@ -42,6 +42,7 @@ minimum_drag = 0.1
 angularDrag = .25
 crashTolerance = 8
 maxTemp = 3400
+bulkheadProfiles = size0
 explosionPotential = 0.1
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadTruss_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadTruss_35.cfg
@@ -45,6 +45,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 12
 maxTemp = 3400
+bulkheadProfiles = size00
 explosionPotential = 0.1
 
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadTruss_35.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadTruss_35.cfg
@@ -45,7 +45,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 12
 maxTemp = 3400
-bulkheadProfiles = size00
+bulkheadProfiles = size0
 explosionPotential = 0.1
 
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadTruss_625.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_PayloadTruss_625.cfg
@@ -45,6 +45,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 12
 maxTemp = 3400
+bulkheadProfiles = size0
 explosionPotential = 0.1
 
 }

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_ProbeCore.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_ProbeCore.cfg
@@ -37,7 +37,7 @@ minimum_drag = 0.2
 angularDrag = 1
 crashTolerance = 8
 maxTemp = 3400 
-
+bulkheadProfiles = srf
 vesselType = Probe
 
 

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
@@ -47,7 +47,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-
+bulkheadProfiles = size00,srf
 stagingIcon = SOLID_BOOSTER
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_01.cfg
@@ -47,7 +47,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-bulkheadProfiles = size00,srf
+bulkheadProfiles = size0,srf
 stagingIcon = SOLID_BOOSTER
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_02.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_02.cfg
@@ -47,7 +47,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-
+bulkheadProfiles = size00,srf
 stagingIcon = SOLID_BOOSTER
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_02.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_35_02.cfg
@@ -47,7 +47,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-bulkheadProfiles = size00,srf
+bulkheadProfiles = size0,srf
 stagingIcon = SOLID_BOOSTER
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_625_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Rocket_625_01.cfg
@@ -47,7 +47,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-
+bulkheadProfiles = size0,srf
 stagingIcon = SOLID_BOOSTER
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Stabilizer.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Stabilizer.cfg
@@ -37,7 +37,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-bulkheadProfiles = size00
+bulkheadProfiles = size0
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Stabilizer.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Stabilizer.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
+bulkheadProfiles = size00
 
 MODULE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Tank_35_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Tank_35_01.cfg
@@ -38,7 +38,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-
+bulkheadProfiles = size00,srf
 
 RESOURCE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Tank_35_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Tank_35_01.cfg
@@ -38,7 +38,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
-bulkheadProfiles = size00,srf
+bulkheadProfiles = size0,srf
 
 RESOURCE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Tank_625_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Tank_625_01.cfg
@@ -38,6 +38,7 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 3400 
+bulkheadProfiles = size0,srf
 
 RESOURCE
 {

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing_01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing_01.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.02
 angularDrag = 5
 crashTolerance = 8
 maxTemp = 3400
+bulkheadProfiles = srf
 explosionPotential = 0.1
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing_02.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing_02.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.02
 angularDrag = 5
 crashTolerance = 8
 maxTemp = 3400
+bulkheadProfiles = srf
 explosionPotential = 0.1
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing_03.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing_03.cfg
@@ -37,6 +37,7 @@ minimum_drag = 0.02
 angularDrag = 5
 crashTolerance = 8
 maxTemp = 3400
+bulkheadProfiles = srf
 explosionPotential = 0.1
 
 	MODULE

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/SR_CargoBays.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/SR_CargoBays.cfg
@@ -1,0 +1,33 @@
+@PART[SR_PayloadFairing_625]:NEEDS[AnimatedDecouplers]
+{
+	@MODULE[ModuleDecouple]
+	{
+		@name = ModuleAnimatedDecoupler
+	}
+	
+	MODULE
+	{
+		name = ModuleCargoBay
+		DeployModuleIndex = 0
+		closedPosition = 0
+		lookupCenter = 0,0.5,0
+		lookupRadius = 0.6
+	}
+}
+
+@PART[SR_PayloadFairing_35]:NEEDS[AnimatedDecouplers]
+{
+	@MODULE[ModuleDecouple]
+	{
+		@name = ModuleAnimatedDecoupler
+	}
+	
+	MODULE
+	{
+		name = ModuleCargoBay
+		DeployModuleIndex = 0
+		closedPosition = 0
+		lookupCenter = 0,0.28,0
+		lookupRadius = 0.3
+	}
+}

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/SR_size00_filterext.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/SR_size00_filterext.cfg
@@ -1,0 +1,14 @@
+@PART[SR_Adapter]:NEEDS[FilterExtensions]
+{
+	@bulkheadProfiles = size0,size00
+}
+
+@PART[SR_Aerospike,SR_Decoupler,SR_Nosecone_35,SR_PayloadFairing_35,SR_PayloadTruss_35,SR_Stabilizer]:NEEDS[FilterExtensions]
+{
+	@bulkheadProfiles = size00
+}
+
+@PART[SR_Gyro,SR_LaunchStick,SR_Rocket_35_01,SR_Rocket_35_02,SR_Tank_35_01]:NEEDS[FilterExtensions]
+{
+	@bulkheadProfiles = size00,srf
+}


### PR DESCRIPTION
Same as [my other PR](https://github.com/BobPalmer/SoundingRockets/pull/20), but with all size 00 parts categorized under size 0 unless Filter Extensions is installed (since that's the one that lets size 00 get an icon and such).