### PR TITLE
Update SR_NoseCone_625.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_625.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_NoseCone_625.cfg
@@ -30,7 +30,7 @@ entryCost = 0
 cost = 250
 category = Utility
 subcategory = 0
-title = Nosecone Parachute (0.35m)
+title = Nosecone Parachute (0.625m)
 manufacturer = Umbra Space Industries
 description = A cardboard cone stuffed with a spare parachute.  A handy, aerodynamic topper for your sounding rocket. 
 


### PR DESCRIPTION
Name is incorrect. I'm not sure what the numbers should be for stowedDrag, minAirPressureToOpen, deployAltitude or etc. It looks like a copy/paste of the 0.35m nosecone and I couldn't find a history where they were different to propose different values there.