### PR TITLE
AntennaRange support

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SR_AntennaRange.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SR_AntennaRange.cfg
@@ -1,0 +1,30 @@
+@PART[SR_Nosecone_*]:FOR[UmbraSpaceIndustries]:NEEDS[AntennaRange,!RemoteTech]
+{
+	MODULE
+	{
+		name = ModuleLimitedDataTransmitter
+
+		nominalRange = 5556
+		simpleRange = 65000
+		maxPowerFactor = 1
+		maxDataFactor = 1
+
+		packetInterval = 0.2
+		packetSize = 1
+		packetResourceCost = 10
+		
+		requiredResource = ElectricCharge
+	}
+
+    // We add this ModuleScienceContainer so that when transmission fails the antennas can try to stash the data instead of dumping it to the void.
+    MODULE
+    {
+        name = ModuleScienceContainer
+
+        dataIsCollectable = true
+        dataIsStorable = false
+
+        storageRange = 2
+    }
+
+}


### PR DESCRIPTION
Allows communication up to about 65km.

NB: transmitting science doesn't work due to a bug in the game; would be nice to get that fixed for 1.1. see https://github.com/toadicus/AntennaRange/issues/4