### PR TITLE
FOR USISoundingRockets instead of UmbraSpaceIndustries 

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SR_AntennaRange.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SR_AntennaRange.cfg
@@ -1,4 +1,4 @@
-@PART[SR_Nosecone_*]:FOR[UmbraSpaceIndustries]:NEEDS[AntennaRange,!RemoteTech]
+@PART[SR_Nosecone_*]:FOR[USISoundingRockets]:NEEDS[AntennaRange,!RemoteTech]
 {
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/kOS_SoundingRockets_MM.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/kOS_SoundingRockets_MM.cfg
@@ -1,4 +1,4 @@
-@PART[SR_ProbeCore]:NEEDS[kOS]:FOR[UmbraSpaceIndustries]
+@PART[SR_ProbeCore]:NEEDS[kOS]:FOR[USISoundingRockets]
 {
 
 MODULE
@@ -10,7 +10,7 @@ MODULE
 }
 
 }
-@PART[SR_InlineProbe]:NEEDS[kOS]:FOR[UmbraSpaceIndustries]
+@PART[SR_InlineProbe]:NEEDS[kOS]:FOR[USISoundingRockets]
 {
 
 MODULE


### PR DESCRIPTION
Changed the :FOR[] block to USISoundingRockets instead of UmbraSpaceIndurstries to allow ModuleManager patches to target just this pack instead of all of USI.